### PR TITLE
net5

### DIFF
--- a/Base64/FromBase64Transform.cs
+++ b/Base64/FromBase64Transform.cs
@@ -85,6 +85,7 @@ namespace Base64
                         nWritten = ASCII.GetChars(startPtr, 4 * numBlocks, cp, bufferSize);
                     }
 
+#if NETFRAMEWORK
                     fixed (byte* op = block.outputBuffer)
                     {
                         int outputBytes = UnsafeConvert.FromBase64CharArray(tempCharBuffer, 0, nWritten, op + block.outputOffset);
@@ -92,7 +93,13 @@ namespace Base64
                         block.outputOffset += outputBytes;
                         totalOutputBytes += outputBytes;
                     }
+#endif
+#if NET5_0_OR_GREATER
+                    Convert.TryFromBase64Chars(tempCharBuffer.AsSpan(), block.outputBuffer.AsSpan().Slice(block.outputOffset), out int outputBytes);
 
+                    block.outputOffset += outputBytes;
+                    totalOutputBytes += outputBytes;
+#endif
                     // If we couldn't write a complete block, try to find 4 bytes starting from the last space.
                     int remainder = effectiveCount % 4;
 
@@ -121,6 +128,7 @@ namespace Base64
                                 nWritten = ASCII.GetChars(tp, 4, cp, bufferSize);
                             }
 
+#if NETFRAMEWORK
                             fixed (byte* op = block.outputBuffer)
                             {
                                 int outputBytes = UnsafeConvert.FromBase64CharArray(tempCharBuffer, 0, nWritten, op + block.outputOffset);
@@ -128,6 +136,13 @@ namespace Base64
                                 block.outputOffset += outputBytes;
                                 totalOutputBytes += outputBytes;
                             }
+#endif
+#if NET5_0_OR_GREATER
+                            Convert.TryFromBase64Chars(tempCharBuffer.AsSpan(), block.outputBuffer.AsSpan().Slice(block.outputOffset), out int outputBytes2);
+
+                            block.outputOffset += outputBytes2;
+                            totalOutputBytes += outputBytes2;
+#endif
 
                             // advance startPtr past the block just written
                             startPtr = tmpPtr;
@@ -225,6 +240,7 @@ namespace Base64
                     nWritten = ASCII.GetChars(tp, 4, cp, bufferSize);
                 }
 
+#if NETFRAMEWORK
                 fixed (byte* op = block.outputBuffer)
                 {
                     int outputBytes = UnsafeConvert.FromBase64CharArray(tempCharBuffer, 0, nWritten, op + block.outputOffset);
@@ -232,6 +248,13 @@ namespace Base64
                     block.outputOffset += outputBytes;
                     totalOutputBytes += outputBytes;
                 }
+#endif
+#if NET5_0_OR_GREATER
+                Convert.TryFromBase64Chars(tempCharBuffer.AsSpan(), block.outputBuffer.AsSpan().Slice(block.outputOffset), out int outputBytes2);
+
+                block.outputOffset += outputBytes2;
+                totalOutputBytes += outputBytes2;
+#endif
 
                 // advance offset
                 int count = (int)(startPtr - (byte*)(inputPtr + block.inputOffset));

--- a/Base64/FromBase64Transform.cs
+++ b/Base64/FromBase64Transform.cs
@@ -95,7 +95,10 @@ namespace Base64
                     }
 #endif
 #if NET5_0_OR_GREATER
-                    Convert.TryFromBase64Chars(tempCharBuffer.AsSpan().Slice(0, nWritten), block.outputBuffer.AsSpan().Slice(block.outputOffset), out int outputBytes);
+                    if (!Convert.TryFromBase64Chars(tempCharBuffer.AsSpan().Slice(0, nWritten), block.outputBuffer.AsSpan().Slice(block.outputOffset), out int outputBytes))
+                    {
+                        throw new FormatException();
+                    }
 
                     block.outputOffset += outputBytes;
                     totalOutputBytes += outputBytes;
@@ -138,7 +141,10 @@ namespace Base64
                             }
 #endif
 #if NET5_0_OR_GREATER
-                            Convert.TryFromBase64Chars(tempCharBuffer.AsSpan().Slice(0, nWritten), block.outputBuffer.AsSpan().Slice(block.outputOffset), out int outputBytes2);
+                            if (!Convert.TryFromBase64Chars(tempCharBuffer.AsSpan().Slice(0, nWritten), block.outputBuffer.AsSpan().Slice(block.outputOffset), out int outputBytes2))
+                            {
+                                throw new FormatException();
+                            }
 
                             block.outputOffset += outputBytes2;
                             totalOutputBytes += outputBytes2;
@@ -250,7 +256,10 @@ namespace Base64
                 }
 #endif
 #if NET5_0_OR_GREATER
-                Convert.TryFromBase64Chars(tempCharBuffer.AsSpan().Slice(0, nWritten), block.outputBuffer.AsSpan().Slice(block.outputOffset), out int outputBytes2);
+                if (!Convert.TryFromBase64Chars(tempCharBuffer.AsSpan().Slice(0, nWritten), block.outputBuffer.AsSpan().Slice(block.outputOffset), out int outputBytes2))
+                {
+                    throw new FormatException();
+                }
 
                 block.outputOffset += outputBytes2;
                 totalOutputBytes += outputBytes2;

--- a/Base64/FromBase64Transform.cs
+++ b/Base64/FromBase64Transform.cs
@@ -95,7 +95,7 @@ namespace Base64
                     }
 #endif
 #if NET5_0_OR_GREATER
-                    Convert.TryFromBase64Chars(tempCharBuffer.AsSpan(), block.outputBuffer.AsSpan().Slice(block.outputOffset), out int outputBytes);
+                    Convert.TryFromBase64Chars(tempCharBuffer.AsSpan().Slice(0, nWritten), block.outputBuffer.AsSpan().Slice(block.outputOffset), out int outputBytes);
 
                     block.outputOffset += outputBytes;
                     totalOutputBytes += outputBytes;
@@ -138,7 +138,7 @@ namespace Base64
                             }
 #endif
 #if NET5_0_OR_GREATER
-                            Convert.TryFromBase64Chars(tempCharBuffer.AsSpan(), block.outputBuffer.AsSpan().Slice(block.outputOffset), out int outputBytes2);
+                            Convert.TryFromBase64Chars(tempCharBuffer.AsSpan().Slice(0, nWritten), block.outputBuffer.AsSpan().Slice(block.outputOffset), out int outputBytes2);
 
                             block.outputOffset += outputBytes2;
                             totalOutputBytes += outputBytes2;
@@ -250,7 +250,7 @@ namespace Base64
                 }
 #endif
 #if NET5_0_OR_GREATER
-                Convert.TryFromBase64Chars(tempCharBuffer.AsSpan(), block.outputBuffer.AsSpan().Slice(block.outputOffset), out int outputBytes2);
+                Convert.TryFromBase64Chars(tempCharBuffer.AsSpan().Slice(0, nWritten), block.outputBuffer.AsSpan().Slice(block.outputOffset), out int outputBytes2);
 
                 block.outputOffset += outputBytes2;
                 totalOutputBytes += outputBytes2;

--- a/Base64/UnsafeConvert.cs
+++ b/Base64/UnsafeConvert.cs
@@ -7,6 +7,7 @@ using System.Text;
 
 namespace Base64
 {
+#if NETFRAMEWORK
     public static class UnsafeConvert
     {
         /// <summary>
@@ -87,4 +88,5 @@ namespace Base64
             }
         }
     }
+#endif
 }


### PR DESCRIPTION
Migrate to public span based convert API, all unit tests pass on net5 target.

```
dotnet run -f net5.0 -c Release --job short --runtimes netcoreapp50 --filter *StringFromBase64Loh*

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.22000
Intel Core i7-1065G7 CPU 1.30GHz, 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.405
  [Host]     : .NET Core 5.0.14 (CoreCLR 5.0.1422.5710, CoreFX 5.0.1422.5710), X64 RyuJIT
  Job-WLZFHQ : .NET Core 5.0.14 (CoreCLR 5.0.1422.5710, CoreFX 5.0.1422.5710), X64 RyuJIT

Runtime=.NET Core 5.0  Toolchain=netcoreapp50  IterationCount=3
LaunchCount=1  WarmupCount=3
```

|      Method |       Mean |    Error |   StdDev | Ratio |    Gen 0 |    Gen 1 |    Gen 2 |  Allocated |
|------------ |-----------:|---------:|---------:|------:|---------:|---------:|---------:|-----------:|
| ConvertFrom | 1,159.8 us | 209.3 us | 11.47 us |  1.00 | 324.2188 | 324.2188 | 324.2188 | 1464.88 KB |
|  StreamFrom | 1,141.5 us | 449.9 us | 24.66 us |  0.98 | 195.3125 | 195.3125 | 195.3125 |  978.05 KB |
|    GetBytes |   181.4 us | 238.4 us | 13.07 us |  0.16 | 137.9395 | 137.9395 | 137.9395 |  651.07 KB |



```
dotnet run -f net5.0 -c Release --job short --runtimes netcoreapp50 --filter *StreamFromBase64*

Runtime=.NET Core 5.0  Toolchain=netcoreapp50  IterationCount=3
LaunchCount=1  WarmupCount=3
```

|      Method |  input |         Mean |         Error |      StdDev | Ratio | RatioSD |    Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|------------ |------- |-------------:|--------------:|------------:|------:|--------:|---------:|---------:|---------:|----------:|
| ConvertFrom |   1024 |   1,885.4 ns |     394.39 ns |    21.62 ns |  1.00 |    0.00 |   0.7439 |        - |        - |    3120 B |
|  StreamFrom |   1024 |   1,874.2 ns |     607.79 ns |    33.31 ns |  0.99 |    0.03 |   0.0401 |        - |        - |     168 B |
|             |        |              |               |             |       |         |          |          |          |           |
| ConvertFrom | 131072 | 335,511.0 ns | 168,510.10 ns | 9,236.61 ns |  1.00 |    0.00 | 124.5117 | 124.5117 | 124.5117 |  393264 B |
|  StreamFrom | 131072 | 217,118.6 ns | 100,933.58 ns | 5,532.51 ns |  0.65 |    0.00 |        - |        - |        - |     168 B |
|             |        |              |               |             |       |         |          |          |          |           |
| ConvertFrom |  16384 |  27,378.6 ns |   6,776.70 ns |   371.45 ns |  1.00 |    0.00 |  11.6882 |        - |        - |   49200 B |
|  StreamFrom |  16384 |  27,171.7 ns |   7,806.86 ns |   427.92 ns |  0.99 |    0.02 |   0.0305 |        - |        - |     168 B |
|             |        |              |               |             |       |         |          |          |          |           |
| ConvertFrom |   2048 |   3,627.9 ns |   1,052.74 ns |    57.70 ns |  1.00 |    0.00 |   1.4763 |        - |        - |    6192 B |
|  StreamFrom |   2048 |   3,564.2 ns |   1,143.63 ns |    62.69 ns |  0.98 |    0.03 |   0.0381 |        - |        - |     168 B |
|             |        |              |               |             |       |         |          |          |          |           |
| ConvertFrom |    256 |     537.5 ns |     106.19 ns |     5.82 ns |  1.00 |    0.00 |   0.1945 |        - |        - |     816 B |
|  StreamFrom |    256 |     628.8 ns |      69.48 ns |     3.81 ns |  1.17 |    0.01 |   0.0401 |        - |        - |     168 B |
|             |        |              |               |             |       |         |          |          |          |           |
| ConvertFrom |  32768 |  55,648.4 ns |  24,753.53 ns | 1,356.82 ns |  1.00 |    0.00 |  23.2544 |        - |        - |   98352 B |
|  StreamFrom |  32768 |  56,219.0 ns |   4,409.07 ns |   241.68 ns |  1.01 |    0.03 |        - |        - |        - |     168 B |
|             |        |              |               |             |       |         |          |          |          |           |
| ConvertFrom |   4096 |   7,147.8 ns |   1,930.95 ns |   105.84 ns |  1.00 |    0.00 |   2.9449 |        - |        - |   12336 B |
|  StreamFrom |   4096 |   7,091.8 ns |   1,949.01 ns |   106.83 ns |  0.99 |    0.03 |   0.0381 |        - |        - |     168 B |
|             |        |              |               |             |       |         |          |          |          |           |
| ConvertFrom |    512 |   1,001.8 ns |      90.77 ns |     4.98 ns |  1.00 |    0.00 |   0.3777 |        - |        - |    1584 B |
|  StreamFrom |    512 |   1,122.2 ns |     228.36 ns |    12.52 ns |  1.12 |    0.02 |   0.0401 |        - |        - |     168 B |
|             |        |              |               |             |       |         |          |          |          |           |
| ConvertFrom |  65536 | 159,749.9 ns |  70,582.66 ns | 3,868.87 ns |  1.00 |    0.00 |  41.5039 |  41.5039 |  41.5039 |  196656 B |
|  StreamFrom |  65536 | 108,982.0 ns | 116,953.01 ns | 6,410.59 ns |  0.68 |    0.05 |        - |        - |        - |     168 B |
|             |        |              |               |             |       |         |          |          |          |           |
| ConvertFrom |   8192 |  13,944.8 ns |   3,303.35 ns |   181.07 ns |  1.00 |    0.00 |   5.8594 |        - |        - |   24624 B |
|  StreamFrom |   8192 |  13,575.3 ns |   4,283.37 ns |   234.79 ns |  0.97 |    0.02 |   0.0305 |        - |        - |     168 B |